### PR TITLE
raise on non supported platform.

### DIFF
--- a/lib/itamae/plugin/recipe/redis/package.rb
+++ b/lib/itamae/plugin/recipe/redis/package.rb
@@ -17,4 +17,6 @@ when 'redhat', 'fedora', 'amazon'
     version redis_version unless redis_version.nil?
     options '--enablerepo=epel'
   end
+else
+  fail "Sorry, your platform(#{node[:platform]}) is not supported yet."
 end


### PR DESCRIPTION
User will use package recipe at first time.

But this recipe do nothing with package recipe on non supported platform.

It seems like that redis installed successfuly...

So this pull request make fail on non supported platform!
